### PR TITLE
remove leading / and fix uploader

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "deploy": "pnpm build && pnpm upload",
-    "upload": "pnpm upload-bundle ./dist testnet partfs1.testnet gornt.testnet",
+    "upload": "pnpm upload-bundle ./dist testnet partfs1.testnet gormp.testnet",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -10,9 +10,8 @@ export default defineConfig({
     name: 'inject-bundle-url',
     apply: 'build',
     transformIndexHtml(html ) {
-      // TODO prefix root-level assets
-      // return html.replace(/(href|src)="\/((?:[\w\s-]+\/)*[^/]+\.js|css)/g, `$1="${deployerAccount}/$2`);
-      return html;
+      // TODO prefix root-level assets - this only removes the leading /
+      return html.replace(/(href|src)="\/((?:[\w\s-]+\/)*[^/]+\.(?:js|css|svg))/g, `$1="$2`);
     }
   }],
   define: {
@@ -23,7 +22,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: {
-          preset: presetBundles.react
+          preset: presetBundles.react,
         },
       },
     },


### PR DESCRIPTION
This PR restores the inline Render plugin responsible for stripping the leading `/` for referenced JS/CSS/SVG assets.

Related to #27 but does not address the issue for absolute imports from JS.