### PR TITLE
Fix list_authors

### DIFF
--- a/packages/paid-storage-contract/src/contract.ts
+++ b/packages/paid-storage-contract/src/contract.ts
@@ -320,8 +320,10 @@ class UserStorage implements StorageManagement {
   list_authors(): string[] {
     // @ts-ignore
     return Object.keys(this.filemap.keys({}).reduce((authors: any, file: string) => {
-      // @ts-ignore
-      authors[file.split('/')[0]] = true;
+      const versionAuthorTokens = file.split('/')[0].split('_');
+      versionAuthorTokens.shift();
+      const author = versionAuthorTokens.join('_');
+      authors[author] = true;
       return authors;
     }, {}));
   }


### PR DESCRIPTION
`list_authors` was including the version prefix. This strips to just the author and accounts for addresses containing `_`